### PR TITLE
COG output on spectf_cloud deploy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,10 +25,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install GDAL dependencies
       run: |
-        sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
         sudo apt-get update
-        sudo apt-get install gdal-bin
-        sudo apt-get install libgdal-dev
+        sudo apt-get install -y gdal-bin libgdal-dev
     - name: Make dev-install
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,8 +25,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install GDAL dependencies
       run: |
-        sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
+        sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
         sudo apt-get update
+        sudo apt-get install gdal-bin
         sudo apt-get install libgdal-dev
     - name: Make dev-install
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install GDAL dependencies
       run: |
+        sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
         sudo apt-get update
         sudo apt-get install -y gdal-bin libgdal-dev
     - name: Make dev-install

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install GDAL dependencies
+      run: |
+        sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
+        sudo apt-get update
+        sudo apt-get install libgdal-dev
     - name: Make dev-install
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository contains code for the Spectroscopic Transformer, a pixel-wise de
 Subdirectories of this repository contain research code for specific publications and/or applications.
 
 ## Included Packages
+
+Installation of these packages require an [existing installation of GDAL](https://gdal.org/en/stable/download.html).
+
 ### [SpecTf Cloud Masking Model](https://github.com/emit-sds/SpecTf/tree/main/spectf_cloud)
 <p align="center">
   <img src="https://raw.githubusercontent.com/emit-sds/SpecTf/refs/heads/dev/spectf_cloud/figures/fig4.png" alt="SpecTf Cloud Model Image" width="300" height="250">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "spectral >= 0.23.1",
   "isofit >= 3.2.2",
   "xgboost >= 2.1.3",
-  "GDAL >= 3.9.0",
+  "GDAL ~= 3.9.0",
 ]
 
 scripts = { spectf-cloud = "spectf_cloud.cli:main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 maintainers = [
   {name = "Michael Kiper", email = "michael.kiper@jpl.nasa.gov"},
+  {name = "Jake Lee", email = "jake.h.lee@jpl.nasa.gov"},
 ]
 dependencies = [
   "torch >= 2.5.1",
@@ -24,6 +25,7 @@ dependencies = [
   "spectral >= 0.23.1",
   "isofit >= 3.2.2",
   "xgboost >= 2.1.3",
+  "GDAL >= 3.9.0",
 ]
 
 scripts = { spectf-cloud = "spectf_cloud.cli:main" }

--- a/spectf_cloud/README.md
+++ b/spectf_cloud/README.md
@@ -24,14 +24,13 @@ To install the `SpecTf Cloud` python package to use as both:
 - A CLI interface for model training and deployment
 follow the below instructions:
 
-1. Install via `pip`  
-```
-pip3 install <tbd until package is deployed on PyPI>
-```
+1. [Install GDAL](https://gdal.org/en/stable/download.html)
+2. `make dev-install` from the repository root.
+3. Future versions will be deployed on PyPI.
 
 
 ## 📁 Project Directory Structure
-Here’s an overview of the key files and directories in this repository:
+Here's an overview of the key files and directories in this repository:
 
 ### **Directories**
 | Directory | Description |


### PR DESCRIPTION
Closes #17 

spectf_cloud deploy now generates COG output files.

Testing:

```
$ spectf-cloud deploy test.tif emit20240302t005829_o06201_s000_l1b_obs_b0106_v01.hdr emit20240302t005829_o06201_s000_l1b_rdn_b0106_v01.hdr --device 0 --proba
[INFO] Device is cuda:0
[INFO] Starting inference.
[INFO] Iter 99: 1.31 min remain.
[INFO] Iter 199: 1.20 min remain.
[INFO] Iter 299: 1.11 min remain.
[INFO] Iter 399: 1.02 min remain.
[INFO] Iter 499: 0.93 min remain.
[INFO] Iter 599: 0.84 min remain.
[INFO] Iter 699: 0.76 min remain.
[INFO] Iter 799: 0.67 min remain.
[INFO] Iter 899: 0.59 min remain.
[INFO] Iter 999: 0.49 min remain.
[INFO] Iter 1099: 0.40 min remain.
[INFO] Iter 1199: 0.31 min remain.
[INFO] Iter 1299: 0.22 min remain.
[INFO] Iter 1399: 0.14 min remain.
[INFO] Iter 1499: 0.05 min remain.
[INFO] Inference complete.
[INFO] Cloud mask saved to test.tif
```