### PR TITLE
Refactor the PyTorch Device Function

### DIFF
--- a/spectf/utils.py
+++ b/spectf/utils.py
@@ -117,3 +117,11 @@ def drop_banddef(banddef: np.ndarray, wls: list = None):
     banddef = np.delete(banddef, dropbands, axis=0)
 
     return banddef
+
+def get_device():
+    if torch.cuda.is_available():
+        return torch.device(f"cuda")
+    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
+        return torch.device("mps") # Apple silicon
+    else:
+        return torch.device("cpu")

--- a/spectf_cloud/comparison_models/ResNet/ResNet.py
+++ b/spectf_cloud/comparison_models/ResNet/ResNet.py
@@ -3,6 +3,7 @@ from torch import nn
 from torch import tensor 
 import yaml
 from typing import List
+from spectf.utils import get_device
 
 class RMSNorm(nn.Module):
     def __init__(self, num_features, eps=1e-8):
@@ -121,11 +122,3 @@ def make_model(arch_yml:str, input_dim:int, num_classes:int, arch_subkeys:List[s
         model.load_state_dict(torch.load(weight_file, map_location=get_device()))
         model.eval()
     return model
-
-def get_device():
-    if torch.cuda.is_available():
-        return torch.device("cuda")
-    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
-        return torch.device("mps") # Apple silicon
-    else:
-        return torch.device("cpu")

--- a/spectf_cloud/comparison_models/train_resnet.py
+++ b/spectf_cloud/comparison_models/train_resnet.py
@@ -21,9 +21,10 @@ from spectf_cloud.comparison_models.training_utils import utils
 from spectf_cloud.comparison_models.ResNet import make_model
 from spectf_cloud.comparison_models import train_comparison
 from spectf.utils import seed as useed
+from spectf.utils import get_device
 
 ENV_VAR_PREFIX = "RESNET_TRAIN_"
-DEVICE = utils.get_device()
+DEVICE = get_device()
 
 os.environ["WANDB__SERVICE_WAIT"] = "300"
 torch.autograd.set_detect_anomaly(True)

--- a/spectf_cloud/comparison_models/training_utils/utils.py
+++ b/spectf_cloud/comparison_models/training_utils/utils.py
@@ -2,14 +2,6 @@ import numpy as np
 import torch
 from sklearn.metrics import fbeta_score
 
-def get_device():
-    if torch.cuda.is_available():
-        return torch.device(f"cuda")
-    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
-        return torch.device("mps") # Apple silicon
-    else:
-        return torch.device("cpu")
-
 def gen_train_test_split(fids, train_split:str, test_split:str, return_fids=False):
     """The 'train_split' and 'test_split' parameters need to be file paths to a text file of fids"""
 

--- a/spectf_cloud/evaluation/eval_spectf.py
+++ b/spectf_cloud/evaluation/eval_spectf.py
@@ -13,7 +13,7 @@ from sklearn.metrics import fbeta_score, roc_auc_score
 
 from spectf.model import SpecTfEncoder
 from spectf.dataset import SpectraDataset
-from spectf.utils import seed
+from spectf.utils import seed, get_device
 from spectf_cloud.evaluation import cloud_eval
 
 ENV_VAR_PREFIX = "SPECTF_EVAL_SPECTF_"
@@ -114,13 +114,7 @@ def spectf(dataset, weights, test_csv, batch, gpu, arch_ff, arch_heads, arch_pro
     print("Loaded dataset with shape:", spectra.shape)
 
     # Device
-    if torch.cuda.is_available():
-        device = torch.device(f"cuda:{gpu}")
-    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
-        # apple silicon
-        device = torch.device("mps")
-    else:
-        device = torch.device("cpu")
+    device = get_device()
 
     # Generate a train/test split that prevents FID leakage
     if test_csv:

--- a/spectf_cloud/train.py
+++ b/spectf_cloud/train.py
@@ -22,6 +22,7 @@ import wandb
 from spectf.dataset import SpectraDataset
 from spectf.model import SpecTfEncoder
 from spectf.utils import seed as useed
+from spectf.utils import get_device
 from spectf_cloud.cli import spectf_cloud
 
 os.environ["WANDB__SERVICE_WAIT"] = "300"
@@ -204,12 +205,7 @@ def train(
         os.mkdir(outdir)
 
     # Device
-    if torch.cuda.is_available():
-        device = torch.device(f"cuda:{gpu}")
-    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
-        device = torch.device("mps")
-    else:
-        device = torch.device("cpu")
+    device = get_device()
 
     print("Using specified train/test splits.")
     # Open train csv


### PR DESCRIPTION
## Overview
This PR is to factor out the PyTorch device identification functionality. This was repeated a number of times in the repository, so it should be consolidated into the `spectf/utils.py` file.

It's important to reduce the redundancy of the repo so that it is more maintainable.

`spectf/utils.py` is the proper place for this functionality as it's meant to house generic support functions, which this device identification function falls under. 
