### PR TITLE
Corrected NODATA Handling

### DIFF
--- a/spectf/toa.py
+++ b/spectf/toa.py
@@ -36,10 +36,6 @@ def l1b_to_toa_arr(rdnfp: str, obsfp: str, irrfp: str):
     banddef = [name_to_nm(name) for name in rad_header.metadata['wavelength']]
     banddef = np.array(banddef, dtype=float)
 
-    # Handle NODATA values
-    nodata_value = -9999.0
-    rad[rad == nodata_value] = np.nan
-
     # To-sun zenith (0 to 90 degrees from zenith)
     obs = envi.open(obsfp).open_memmap(interleave='bip')
     zen = obs[:,:,4]
@@ -62,5 +58,9 @@ def l1b_to_toa_arr(rdnfp: str, obsfp: str, irrfp: str):
 
     # Top of Atmosphere Reflectance
     toa_refl = (np.pi / np.cos(zen[:, :, np.newaxis])) * (rad / irr[np.newaxis, np.newaxis, :])
+    
+    # Handle NODATA values
+    nodata_value = -9999.0
+    toa_refl[rad == nodata_value] = np.nan
 
     return toa_refl, banddef, rad_header.metadata

--- a/spectf/toa.py
+++ b/spectf/toa.py
@@ -36,6 +36,10 @@ def l1b_to_toa_arr(rdnfp: str, obsfp: str, irrfp: str):
     banddef = [name_to_nm(name) for name in rad_header.metadata['wavelength']]
     banddef = np.array(banddef, dtype=float)
 
+    # Handle NODATA values
+    nodata_value = -9999.0
+    rad[rad == nodata_value] = np.nan
+
     # To-sun zenith (0 to 90 degrees from zenith)
     obs = envi.open(obsfp).open_memmap(interleave='bip')
     zen = obs[:,:,4]

--- a/spectf_cloud/deploy.py
+++ b/spectf_cloud/deploy.py
@@ -185,10 +185,7 @@ def deploy(
     # Inference
 
     logging.info("Starting inference.")
-    if proba:
-        cloud_mask = np.zeros((dataset.shape[0]*dataset.shape[1],)).astype(np.float32)
-    else:
-        cloud_mask = np.zeros((dataset.shape[0]*dataset.shape[1],)).astype(np.uint8)
+    cloud_mask = np.zeros((dataset.shape[0]*dataset.shape[1],)).astype(np.float32)
     total_len = len(dataloader)
     with torch.inference_mode():
         curr = 0
@@ -200,14 +197,7 @@ def deploy(
             proba_ = proba_.cpu().detach().numpy()[:,1]
 
             nxt = curr+batch.size()[0]
-            if proba:
-                cloud_mask[curr:nxt] = proba_
-            else:
-                cloud_mask[curr:nxt] = (proba_ >= threshold).astype(np.uint8)
-
-            # Handle NODATA pixels by setting cloud probability to 0 if any band is below -1
-            min_values, _ = torch.min(batch[:,:,0], dim=1)
-            cloud_mask[curr:nxt] = np.where(min_values.cpu().detach().numpy() < -1, 0, cloud_mask[curr:nxt])
+            cloud_mask[curr:nxt] = proba_
 
             curr = nxt
             if (i+1) % 100 == 0:
@@ -217,12 +207,28 @@ def deploy(
 
     logging.info("Inference complete.")
 
+    # Account for NODATA values and threshold
+    if proba:
+        cloud_mask[np.isnan(cloud_mask)] = -9999
+    else:
+        cloud_mask[cloud_mask < threshold] = 0
+        cloud_mask[cloud_mask > 0] = 1
+        cloud_mask[np.isnan(cloud_mask)] = 255
+        cloud_mask = cloud_mask.astype(np.uint8)
+
+
     # Reshape into input shape
     cloud_mask = cloud_mask.reshape((dataset.shape[0], dataset.shape[1], 1))
 
     driver = gdal.GetDriverByName('MEM')
     ds = driver.Create('', cloud_mask.shape[1], cloud_mask.shape[0], cloud_mask.shape[2], numpy_to_gdal[cloud_mask.dtype])
     ds.GetRasterBand(1).WriteArray(cloud_mask[:,:,0])
+
+    # Set NODATA value
+    if proba:
+        ds.GetRasterBand(1).SetNoDataValue(-9999)
+    else:
+        ds.GetRasterBand(1).SetNoDataValue(255)
 
     tiff_driver = gdal.GetDriverByName('GTiff')
     _ = tiff_driver.CreateCopy(outfp, ds, options=['COMPRESS=LZW', 'COPY_SRC_OVERVIEWS=YES', 'TILED=YES', 'BLOCKXSIZE=256', 'BLOCKYSIZE=256'])


### PR DESCRIPTION
Closes #46 

## Description

EMIT scenes have dropped rows due to cloud cover, etc. with a NODATA value of `-9999`. Previously, the produced cloud masks simply set these rows to 0. Instead, we now correctly set these regions to a NODATA value, further simplifying downstream tasks such as orthorectification.

The TOA reflectance calculation, dataloader, and other tasks now treat NODATA as `np.nan`. This allows NODATA values to be propagated throughout without any additional effort then replaced with any constant during file export.

* Float masks (with `--proba`)
  * Mask values are floats between 0 and 1, where 1 indicates 100% probability of cloud cover
  * `NODATA=-9999.0`
* Binary masks (default)
  * Mask values are 0 and 1, where 1 indicates cloud cover.
  * `NODATA=255`

## Testing

The following produced valid masks:

```
$ spectf-cloud deploy test.tif emit20230131t071421_o03105_s000_l1b_obs_b0106_v01.hdr emit20230131t071421_o03105_s000_l1b_rdn_b0106_v01.hdr --device 0
$ spectf-cloud deploy test.tif emit20230131t071421_o03105_s000_l1b_obs_b0106_v01.hdr emit20230131t071421_o03105_s000_l1b_rdn_b0106_v01.hdr --device 0 --proba
```