### PR TITLE
Deploy default options made relative to file

### DIFF
--- a/spectf_cloud/cli.py
+++ b/spectf_cloud/cli.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import rich_click as click
 from rich.traceback import install
 from trogon import tui
@@ -10,6 +11,7 @@ MAIN_CALL_ERR_MSG = """
 """
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+DEFAULT_DIR = Path(__file__).resolve().parent
 
 install()
 

--- a/spectf_cloud/deploy.py
+++ b/spectf_cloud/deploy.py
@@ -8,6 +8,7 @@ Author: Jake Lee, jake.h.lee@jpl.nasa.gov
 
 import logging
 import time
+from pathlib import Path
 
 import yaml
 import rich_click as click
@@ -23,6 +24,8 @@ from spectf.dataset import RasterDatasetTOA
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG
 
 ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
+
+DEFAULT_DIR = Path(__file__).resolve().parent
 
 numpy_to_gdal = {
     np.dtype(np.float64): 7,
@@ -80,7 +83,7 @@ logging.basicConfig(
 )
 @click.option(
     "--weights",
-    default="weights.pt",
+    default=DEFAULT_DIR/"weights.pt",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to trained model weights.",
@@ -88,7 +91,7 @@ logging.basicConfig(
 )
 @click.option(
     "--irradiance",
-    default="irr.npy",
+    default=DEFAULT_DIR/"irr.npy",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to irradiance numpy file.",
@@ -96,7 +99,7 @@ logging.basicConfig(
 )
 @click.option(
     "--arch-spec",
-    default="spectf_cloud_config.yml",
+    default=DEFAULT_DIR/"spectf_cloud_config.yml",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to model architecture YAML specification. This file also needs to contain the bands to remove",

--- a/spectf_cloud/deploy.py
+++ b/spectf_cloud/deploy.py
@@ -21,11 +21,10 @@ from torch.utils.data import DataLoader
 
 from spectf.model import SpecTfEncoder
 from spectf.dataset import RasterDatasetTOA
-from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG
+from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
 ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
 
-DEFAULT_DIR = Path(__file__).resolve().parent
 
 numpy_to_gdal = {
     np.dtype(np.float64): 7,


### PR DESCRIPTION
Closes #33 

## Description

Default filepaths for the deploy script were relative to the path of the call, not the path of the script file. This fix simply appends `Path(__file__).resolve().parent` to the filenames so that `spectf-cloud deploy` can be called from anywhere.

## Testing

The following produced valid masks from outside of the `/spectf_cloud` directory.

```
$ spectf-cloud deploy test.tif emit20230131t071421_o03105_s000_l1b_obs_b0106_v01.hdr emit20230131t071421_o03105_s000_l1b_rdn_b0106_v01.hdr --device 0
```