### PR TITLE
fixed pypi build to include non-python files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include spectf *
+recursive-include spectf_cloud *
+recursive-include docs *

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help: ## Show this help.
 ## Building:
 build: ## Build project artifact
 	$(PYTHON_COMMAND) -m pip install --upgrade build
-	$(PYTHON_COMMAND) -m build
+	$(PYTHON_COMMAND) -m build --wheel --sdist .
 
 clean: ## Clean project
 	rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,11 @@ dev-install: ## Locally install project in development mode
 
 test: ## Quickly run unit tests
 	$(PYTHON_COMMAND) -m unittest discover -s tests
+
+upload: ## Upload SpecTf python build to PyPI
+	$(PYTHON_COMMAND) -m pip install --upgrade twine
+	twine upload dist/*
+
+upload-test: ## Upload SpecTf python build to TestPyPI
+	$(PYTHON_COMMAND) -m pip install --upgrade twine
+	twine upload -r testpypi dist/*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Subdirectories of this repository contain research code for specific publication
 ## Included Packages
 
 Installation of these packages require an [existing installation of GDAL](https://gdal.org/en/stable/download.html).
+- libgdal needs to be version 3.9.3: `conda install conda-forge::libgdal==3.9.3`
 
 ### [SpecTf Cloud Masking Model](https://github.com/emit-sds/SpecTf/tree/main/spectf_cloud)
 <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["spectf", "spectf_cloud"]
+include-package-data = true


### PR DESCRIPTION
## Overview
This PR is to finalize the PyPI building process

## Related Tickets
resolves https://github.com/emit-sds/SpecTf/issues/2

## Testing:

```
$ conda install conda-forge::libgdal==3.9.3
$ pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple spectf==1.0.1
```