### PR TITLE
TensorRT import resolution

### DIFF
--- a/spectf_cloud/cli.py
+++ b/spectf_cloud/cli.py
@@ -83,7 +83,11 @@ class SpecTfCliMetadata(object):
 
 ## Add in all of the subcommands here
 from spectf_cloud import train, evaluation, comparison_models
-from spectf_cloud.deploy import deploy_trt, deploy_pt 
+from spectf_cloud.deploy import deploy_pt 
+try:
+    from spectf_cloud.deploy import deploy_trt
+except (ModuleNotFoundError, ImportError):
+    pass
 
 def main() -> None:
     spectf_cloud(obj=SpecTfCliMetadata())

--- a/spectf_cloud/deploy/__init__.py
+++ b/spectf_cloud/deploy/__init__.py
@@ -9,5 +9,5 @@ try:
     import pycuda.driver as cuda
     from spectf_cloud.deploy import deploy_trt
     __all__.append('deploy_trt')
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     pass

--- a/spectf_cloud/deploy/__init__.py
+++ b/spectf_cloud/deploy/__init__.py
@@ -1,12 +1,13 @@
 __all__ = [
     'deploy_pt',
 ]
-from importlib.util import find_spec
-
 from spectf_cloud.deploy import deploy_pt
 
-_deps = ['tensorrt', 'pycuda']
-__SUPPORTS_TRT__ = all(find_spec(d) for d in _deps)
-if __SUPPORTS_TRT__:
+# Only load deploy_trt if TensorRT is available
+try:
+    import tensorrt as trt
+    import pycuda.driver as cuda
     from spectf_cloud.deploy import deploy_trt
     __all__.append('deploy_trt')
+except ModuleNotFoundError:
+    pass

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -10,7 +10,6 @@ This version of the dployment script quantizes the model, and runs it with Nvidi
 
 import logging
 import time
-from importlib.util import find_spec
 
 import yaml
 import rich_click as click
@@ -25,13 +24,10 @@ from spectf.model import BandConcat
 from spectf.dataset import RasterDatasetTOA
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
-_deps = ['tensorrt', 'pycuda']
-__SUPPORTS_TRT__ = all(find_spec(d) for d in _deps)
-if __SUPPORTS_TRT__:
-    from spectf_cloud.deploy.tensor_rt_model import load_model_network_engine
-    import tensorrt as trt
-    import pycuda.driver as cuda
-    import pycuda.autoinit
+from spectf_cloud.deploy.tensor_rt_model import load_model_network_engine
+import tensorrt as trt
+import pycuda.driver as cuda
+import pycuda.autoinit
 
 PRECISION = torch.bfloat16
 ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'


### PR DESCRIPTION
Closes #72

TensorRT must be importable for deploy-trt to become available.

**Testing:**

```
$ make dev-install
Successfully installed spectf-1.0.1
$ spectf-cloud -h

 Usage: spectf-cloud [OPTIONS] COMMAND [ARGS]...                                
                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --version        Display the current SpecTf version.                         │
│ --help     -h    Show this message and exit.                                 │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ cloud-eval        Evaluation commands for SpecTf and L2A Baseline.           │
│ deploy-pt         Produce a SpecTf transformer-generated cloud mask using    │
│                   PyTorch runtime.                                           │
│ train             Train the SpecTf Hyperspectral Transformer Model.          │
│ train-comparison  Training commands for the ResNet and XGBoost comparison    │
│                   models.                                                    │
│ tui               Open Textual TUI.                                          │
╰──────────────────────────────────────────────────────────────────────────────╯

$ pip uninstall spectf
Successfully uninstalled spectf-0.0.2

$ make dev-install-tensorrt
Successfully installed spectf-1.0.1 tensorrt-10.9.0.34

$ spectf-cloud -h
                                                                                
 Usage: spectf-cloud [OPTIONS] COMMAND [ARGS]...                                
                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --version        Display the current SpecTf version.                         │
│ --help     -h    Show this message and exit.                                 │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ cloud-eval        Evaluation commands for SpecTf and L2A Baseline.           │
│ deploy-pt         Produce a SpecTf transformer-generated cloud mask using    │
│                   PyTorch runtime.                                           │
│ deploy-trt        Produce a SpecTf transformer-generated cloud mask using    │
│                   the TensorRT engine.                                       │
│ train             Train the SpecTf Hyperspectral Transformer Model.          │
│ train-comparison  Training commands for the ResNet and XGBoost comparison    │
│                   models.                                                    │
│ tui               Open Textual TUI.                                          │
╰──────────────────────────────────────────────────────────────────────────────╯

$ spectf-cloud deploy-trt -h
                                                                                
 Usage: spectf-cloud deploy-trt [OPTIONS] OUTFP OBSFP RDNFP                     
                                                                                
 Produce a SpecTf transformer-generated cloud mask using the TensorRT engine.   
                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --threshold       FLOAT  Threshold for cloud classification. [default: 0.52] │
│ --arch-spec       FILE   Filepath to model architecture YAML specification.  │
│                          This file also needs to contain the bands to remove │
│                          [default:                                           │
│                          /home/jakelee/SpecTf/spectf_cloud/spectf_cloud_con… │
│ --irradiance      FILE   Filepath to irradiance numpy file.                  │
│                          [default:                                           │
│                          /home/jakelee/SpecTf/spectf_cloud/irr.npy]          │
│ --engine          FILE   Filepath to TensoRT model engine.                   │
│                          [default:                                           │
│                          /home/jakelee/SpecTf/spectf_cloud/deploy/model.eng… │
│ --proba                  Output probability map instead of binary cloud      │
│                          mask.                                               │
│ --keep-bands             Keep all bands in the spectra (use for non-EMIT     │
│                          data).                                              │
│ --help        -h         Show this message and exit.                         │
╰──────────────────────────────────────────────────────────────────────────────╯


```