### PR TITLE
Update model classification threshold

### DIFF
--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -116,7 +116,7 @@ logging.basicConfig(
 )
 @click.option(
     "--threshold",
-    default=0.52,
+    default=0.51,
     type=float,
     show_default=True,
     help="Threshold for cloud classification.",

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -112,7 +112,7 @@ logging.basicConfig(
 )
 @click.option(
     "--threshold",
-    default=0.52,
+    default=0.51,
     type=float,
     show_default=True,
     help="Threshold for cloud classification.",


### PR DESCRIPTION
## Overview
This PR simply changes the classification threshold from 0.52 (v0 model) to 0.51 (v1 model)

## Related Tickets
resolves https://github.com/emit-sds/SpecTf/issues/78