### PR TITLE
Generalize deploy steps and add TOA xarray data structure

### DIFF
--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from typing import List
 
 import numpy as np
+import xarray as xr
 import torch
 from torch.utils.data import Dataset
 
@@ -18,9 +19,10 @@ from spectf.toa import l1b_to_toa_arr
 from spectf.utils import drop_bands, envi_header
 
 
-class RasterDatasetTOA(Dataset):
-    """A PyTorch dataset class for pixelwise access of top-of-atmosphere (TOA)
-    reflectance data derived from L1b rdn.
+class ToaDataset(Dataset):
+    """
+    A Parent class for PyTorch datasets for pixelwise access of top-of-atmosphere (TOA)
+    reflectance data.
 
     Attributes:
         shape (tuple): Shape of the L1b rdn raster.
@@ -28,6 +30,65 @@ class RasterDatasetTOA(Dataset):
         banddef (np.array): Band wavelengths corresponding to `toa_arr` indices.
         metadata (dict): Metadata of the original raster image.
         transform (callable, optional): Transformations for each pixel spectra.
+
+    """
+
+    # Class attributes
+    toa_arr = None
+    transform = None
+    metadata = None
+    shape = None
+    banddef = None
+
+    def init_class_data(self,
+                        rm_bands: List[List[int]]=None,
+                        transform: Callable = None,
+                        dtype: torch.dtype = torch.float,
+                        device: torch.device = None):
+        """
+        Helper method to initialize class data common to all TOA datasets AFTER toa_arr has been set.
+
+        Args:
+            rm_bands: List[List[int]]=None: if None - keep all bands on non-EMIT data, else drop specified bands.
+            transform: Callable = None: Optional transform to be applied to each spectral data point.
+            dtype: torch.dtype = torch.float: data type to load data as
+            device: torch.device = None - if provided torch device to load data onto
+
+        Returns:
+
+        """
+        if self.toa_arr is None:
+            raise ValueError("toa_arr must be set before calling init_class_data.")
+
+        self.shape = self.toa_arr.shape
+        self.toa_arr = self.toa_arr.reshape((self.shape[0] * self.shape[1],
+                                             self.shape[2]))
+        if rm_bands is not None:
+            self.toa_arr, self.banddef = drop_bands(self.toa_arr,
+                                                    self.banddef,
+                                                    rm_bands,
+                                                    nan=False)
+        self.transform = transform
+
+        self.toa_arr = torch.tensor(self.toa_arr, dtype=dtype)
+        self.toa_arr = torch.unsqueeze(self.toa_arr, -1)
+        if device is not None:
+            self.toa_arr = self.toa_arr.to(device)
+
+    def __len__(self):
+        return len(self.toa_arr)
+
+    def __getitem__(self, idx):
+        out_spec = self.toa_arr[idx]
+        if self.transform is not None:
+            out_spec = self.transform(out_spec)
+
+        return out_spec
+
+
+class RasterDatasetTOA(ToaDataset):
+    """A PyTorch dataset class for pixelwise access of top-of-atmosphere (TOA)
+    reflectance data derived from L1b rdn.
 
     Relies on the `l1b_to_toa_arr` function to process input data files and generate
     TOA reflectance data.
@@ -64,30 +125,35 @@ class RasterDatasetTOA(Dataset):
         assert os.path.exists(irrfp), f"Irradiance file {irrfp} does not exist."
 
         self.toa_arr, self.banddef, self.metadata = l1b_to_toa_arr(self.rdnhdr, self.obshdr, irrfp)
-        self.shape = self.toa_arr.shape
-        self.toa_arr = self.toa_arr.reshape((self.shape[0] * self.shape[1],
-                                             self.shape[2]))
-        if not keep_bands:
-            self.toa_arr, self.banddef = drop_bands(self.toa_arr,
-                                                    self.banddef, 
-                                                    rm_bands,
-                                                    nan=False)
-        self.transform = transform
+        self.init_class_data(rm_bands, transform, dtype, device)
 
-        self.toa_arr = torch.tensor(self.toa_arr, dtype=dtype)
-        self.toa_arr = torch.unsqueeze(self.toa_arr, -1)
-        if device is not None:
-            self.toa_arr = self.toa_arr.to(device)
+class XarrayDatasetTOA(ToaDataset):
+    """
+    A PyTorch dataset class for pixelwise access of top-of-atmosphere (TOA)
+    reflectance data derived from toa xarray dataset.
+    """
+    def __init__(
+        self,
+        toa: xr.DataArray,
+        rm_bands: List[List[int]] | None = None,
+        transform: Callable = None,
+        dtype: torch.dtype = torch.float,
+        device: torch.device = None,
+    ):
+        """
+        Initialize the XarrayDatasetTOA Dataset object.
 
-    def __len__(self):
-        return len(self.toa_arr)
+        Args:
+            toa: xarray dataset of top of atmosphere reflectance.
+            rm_bands (List[List[int]] | None): if None - keep all bands on non-EMIT data, else drop specified bands.
+            transform: Callable = None: Optional transform to be applied to each spectral data point.
+            dtype: torch.dtype = torch.float: data type to load data as
+            device: torch.device = None - if provided torch device to load data onto
+        """
+        super().__init__()
 
-    def __getitem__(self, idx):
-        out_spec = self.toa_arr[idx]
-        if self.transform is not None:
-            out_spec = self.transform(out_spec)
-
-        return out_spec
+        self.toa_arr = toa.values
+        self.init_class_data(rm_bands, transform, dtype, device)
 
 
 class SpectraDataset(Dataset):

--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -34,13 +34,21 @@ class ToaDataset(Dataset):
     """
 
     # Class attributes
-    toa_arr = None
-    transform = None
-    metadata = None
-    shape = None # NOTE this is the dataset shape before reshaping to (num_pixels, num_bands)
-    # This shape should be in order of (rows, cols, bands) or (cols, rows, bands)
+    # toa_arr - the main top of atmosphere reflectance data array, should be in shape (rows, cols, bands)
+    toa_arr: np.ndarray = None
 
-    banddef = None
+    # Optional transform callable method to be applied to each spectral data point
+    transform: Callable | None = None
+
+    # Metadata dictionary of the original raster image - not used in the dataset class, but stored
+    metadata: dict = None
+
+    # NOTE this is the original dataset shape - this should be in order of (rows, cols, bands) or (cols, rows, bands)
+    shape: tuple = None
+
+    # array of band wavelengths corresponding to the indices of the third dimension of toa_arr
+    # used for band dropping when requested
+    banddef: np.ndarray = None
 
     def init_class_data(
         self,

--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -11,7 +11,6 @@ from collections.abc import Callable
 from typing import List
 
 import numpy as np
-import xarray as xr
 import torch
 from torch.utils.data import Dataset
 
@@ -137,24 +136,27 @@ class RasterDatasetTOA(ToaDataset):
         self.toa_arr, self.banddef, self.metadata = l1b_to_toa_arr(self.rdnhdr, self.obshdr, irrfp)
         self.init_class_data(rm_bands, transform, dtype, device)
 
-class XarrayDatasetTOA(ToaDataset):
+class ArrayDatasetTOA(ToaDataset):
     """
     A PyTorch dataset class for pixelwise access of top-of-atmosphere (TOA)
-    reflectance data derived from toa xarray dataset.
+    reflectance data derived from toa numpy array.
     """
     def __init__(
         self,
-        toa: xr.DataArray,
+        toa: np.ndarray,
+        banddef: np.ndarray,
         rm_bands: List[List[int]] = None,
         transform: Callable = None,
         dtype: torch.dtype = torch.float,
         device: torch.device = None,
     ):
         """
-        Initialize the XarrayDatasetTOA Dataset object.
+        Initialize the ArrayDatasetTOA Dataset object.
 
         Args:
-            toa: xarray dataset of top of atmosphere reflectance.
+            toa: numpy array of top of atmosphere reflectance, should be in shape (rows, cols, bands)
+            banddef: numpy array of band wavelengths corresponding to the indices of the third dimension of toa_arr
+                used for band dropping when requested
             rm_bands (List[List[int]] | None): if None - keep all bands on non-EMIT data, else drop specified bands.
             transform: Callable = None: Optional transform to be applied to each spectral data point.
             dtype: torch.dtype = torch.float: data type to load data as
@@ -162,8 +164,8 @@ class XarrayDatasetTOA(ToaDataset):
         """
         super().__init__()
 
-        self.toa_arr = toa.values
-        self.banddef = toa.banddef.values
+        self.toa_arr = toa
+        self.banddef = banddef
         self.init_class_data(rm_bands, transform, dtype, device)
 
 

--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -8,7 +8,7 @@ Author: Jake Lee, jake.h.lee@jpl.nasa.gov
 
 import os
 from collections.abc import Callable
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import torch
@@ -37,7 +37,7 @@ class ToaDataset(Dataset):
     toa_arr: np.ndarray = None
 
     # Optional transform callable method to be applied to each spectral data point
-    transform: Callable | None = None
+    transform: Optional[Callable] = None
 
     # Metadata dictionary of the original raster image - not used in the dataset class, but stored
     metadata: dict = None

--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -1,4 +1,4 @@
-"""Defines PyTorch dataset classes for loading raster or HDF5 data.
+""" Defines PyTorch dataset classes for loading raster or HDF5 data.
 
 Copyright 2025 California Institute of Technology
 Apache License, Version 2.0
@@ -50,13 +50,11 @@ class ToaDataset(Dataset):
     # used for band dropping when requested
     banddef: np.ndarray = None
 
-    def init_class_data(
-        self,
-        rm_bands: List[List[int]] = None,
-        transform: Callable = None,
-        dtype: torch.dtype = torch.float,
-        device: torch.device = None,
-    ):
+    def init_class_data(self,
+                        rm_bands: List[List[int]]=None,
+                        transform: Callable = None,
+                        dtype: torch.dtype = torch.float,
+                        device: torch.device = None):
         """
         Helper method to initialize class data common to all TOA datasets AFTER toa_arr has been set.
 
@@ -73,13 +71,13 @@ class ToaDataset(Dataset):
             raise ValueError("toa_arr must be set before calling init_class_data.")
 
         self.shape = self.toa_arr.shape
-        self.toa_arr = self.toa_arr.reshape(
-            (self.shape[0] * self.shape[1], self.shape[2])
-        )
+        self.toa_arr = self.toa_arr.reshape((self.shape[0] * self.shape[1],
+                                             self.shape[2]))
         if rm_bands is not None:
-            self.toa_arr, self.banddef = drop_bands(
-                self.toa_arr, self.banddef, rm_bands, nan=False
-            )
+            self.toa_arr, self.banddef = drop_bands(self.toa_arr,
+                                                    self.banddef,
+                                                    rm_bands,
+                                                    nan=False)
         self.transform = transform
 
         self.toa_arr = torch.tensor(self.toa_arr, dtype=dtype)
@@ -107,17 +105,17 @@ class RasterDatasetTOA(ToaDataset):
     """
 
     def __init__(
-        self,
-        rdnfp: str,
-        obsfp: str,
-        irrfp: str,
-        rm_bands: List[List[int]] = None,
-        transform: Callable = None,
-        keep_bands: bool = False,
-        dtype: torch.dtype = torch.float,
-        device: torch.device = None,
-    ):
-        """Initialize the RasterDatasetTOA Dataset object.
+            self, 
+            rdnfp: str, 
+            obsfp: str, 
+            irrfp: str,
+            rm_bands: List[List[int]]=None,
+            transform: Callable = None, 
+            keep_bands: bool = False, 
+            dtype: torch.dtype = torch.float,
+            device: torch.device = None,
+        ):
+        """ Initialize the RasterDatasetTOA Dataset object.
         Args:
             rdnfp (str): File path to the radiance data (L1b product).
             obsfp (str): File path to the observation data (L1b product).
@@ -136,18 +134,14 @@ class RasterDatasetTOA(ToaDataset):
         assert os.path.exists(self.obshdr), f"Header file {self.obshdr} does not exist."
         assert os.path.exists(irrfp), f"Irradiance file {irrfp} does not exist."
 
-        self.toa_arr, self.banddef, self.metadata = l1b_to_toa_arr(
-            self.rdnhdr, self.obshdr, irrfp
-        )
+        self.toa_arr, self.banddef, self.metadata = l1b_to_toa_arr(self.rdnhdr, self.obshdr, irrfp)
         self.init_class_data(rm_bands, transform, dtype, device)
-
 
 class XarrayDatasetTOA(ToaDataset):
     """
     A PyTorch dataset class for pixelwise access of top-of-atmosphere (TOA)
     reflectance data derived from toa xarray dataset.
     """
-
     def __init__(
         self,
         toa: xr.DataArray,
@@ -178,24 +172,19 @@ class SpectraDataset(Dataset):
 
     This dataset class is designed specifically for the dataset provided in:
     https://zenodo.org/records/14614218
-
+    
     Attributes:
         spectra (ndarray): The spectral data.
         labels (ndarray): The corresponding labels for the spectral data.
-        transform (callable): Transformations or normalizations
+        transform (callable): Transformations or normalizations 
                               for each spectral data point.
         device (str): The device to load the data onto (e.g., 'cpu', 'cuda:0').
     """
 
-    def __init__(
-        self,
-        spectra: np.ndarray,
-        labels: np.ndarray,
-        transform: bool = None,
-        device: str = "cpu",
-    ):
-        """Initialize the SpectraDataset object.
-
+    def __init__(self, spectra: np.ndarray, labels: np.ndarray,
+                 transform: bool = None, device: str = 'cpu'):
+        """ Initialize the SpectraDataset object.
+        
         Args:
             spectra (np.ndarray): The spectral data.
             labels (np.ndarray): The corresponding labels for the spectral data.
@@ -207,7 +196,7 @@ class SpectraDataset(Dataset):
         self.spectra = torch.tensor(spectra, dtype=torch.float32).to(device)
 
         self.labels = torch.tensor(labels).to(device)
-        self.labels[self.labels == 2] = 0  # shadow considered clear
+        self.labels[self.labels==2] = 0 # shadow considered clear
 
         self.transform = transform
 
@@ -215,8 +204,12 @@ class SpectraDataset(Dataset):
         return len(self.labels)
 
     def __getitem__(self, idx):
+
         out_spec = self.spectra[idx]
         if self.transform is not None:
             out_spec = self.transform(out_spec)
 
-        return {"spectra": torch.unsqueeze(out_spec, -1), "label": self.labels[idx]}
+        return {
+            'spectra': torch.unsqueeze(out_spec, -1),
+            'label': self.labels[idx]
+        }

--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -37,7 +37,9 @@ class ToaDataset(Dataset):
     toa_arr = None
     transform = None
     metadata = None
-    shape = None
+    shape = None # NOTE this is the dataset shape before reshaping to (num_pixels, num_bands)
+    # This shape should be in order of (rows, cols, bands) or (cols, rows, bands)
+
     banddef = None
 
     def init_class_data(
@@ -159,6 +161,7 @@ class XarrayDatasetTOA(ToaDataset):
         super().__init__()
 
         self.toa_arr = toa.values
+        self.banddef = toa.banddef.values
         self.init_class_data(rm_bands, transform, dtype, device)
 
 

--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -151,7 +151,7 @@ class XarrayDatasetTOA(ToaDataset):
     def __init__(
         self,
         toa: xr.DataArray,
-        rm_bands: List[List[int]] | None = None,
+        rm_bands: List[List[int]] = None,
         transform: Callable = None,
         dtype: torch.dtype = torch.float,
         device: torch.device = None,

--- a/spectf/dataset.py
+++ b/spectf/dataset.py
@@ -1,4 +1,4 @@
-""" Defines PyTorch dataset classes for loading raster or HDF5 data.
+"""Defines PyTorch dataset classes for loading raster or HDF5 data.
 
 Copyright 2025 California Institute of Technology
 Apache License, Version 2.0
@@ -40,11 +40,13 @@ class ToaDataset(Dataset):
     shape = None
     banddef = None
 
-    def init_class_data(self,
-                        rm_bands: List[List[int]]=None,
-                        transform: Callable = None,
-                        dtype: torch.dtype = torch.float,
-                        device: torch.device = None):
+    def init_class_data(
+        self,
+        rm_bands: List[List[int]] = None,
+        transform: Callable = None,
+        dtype: torch.dtype = torch.float,
+        device: torch.device = None,
+    ):
         """
         Helper method to initialize class data common to all TOA datasets AFTER toa_arr has been set.
 
@@ -61,13 +63,13 @@ class ToaDataset(Dataset):
             raise ValueError("toa_arr must be set before calling init_class_data.")
 
         self.shape = self.toa_arr.shape
-        self.toa_arr = self.toa_arr.reshape((self.shape[0] * self.shape[1],
-                                             self.shape[2]))
+        self.toa_arr = self.toa_arr.reshape(
+            (self.shape[0] * self.shape[1], self.shape[2])
+        )
         if rm_bands is not None:
-            self.toa_arr, self.banddef = drop_bands(self.toa_arr,
-                                                    self.banddef,
-                                                    rm_bands,
-                                                    nan=False)
+            self.toa_arr, self.banddef = drop_bands(
+                self.toa_arr, self.banddef, rm_bands, nan=False
+            )
         self.transform = transform
 
         self.toa_arr = torch.tensor(self.toa_arr, dtype=dtype)
@@ -95,17 +97,17 @@ class RasterDatasetTOA(ToaDataset):
     """
 
     def __init__(
-            self, 
-            rdnfp: str, 
-            obsfp: str, 
-            irrfp: str,
-            rm_bands: List[List[int]]=None,
-            transform: Callable = None, 
-            keep_bands: bool = False, 
-            dtype: torch.dtype = torch.float,
-            device: torch.device = None,
-        ):
-        """ Initialize the RasterDatasetTOA Dataset object.
+        self,
+        rdnfp: str,
+        obsfp: str,
+        irrfp: str,
+        rm_bands: List[List[int]] = None,
+        transform: Callable = None,
+        keep_bands: bool = False,
+        dtype: torch.dtype = torch.float,
+        device: torch.device = None,
+    ):
+        """Initialize the RasterDatasetTOA Dataset object.
         Args:
             rdnfp (str): File path to the radiance data (L1b product).
             obsfp (str): File path to the observation data (L1b product).
@@ -124,14 +126,18 @@ class RasterDatasetTOA(ToaDataset):
         assert os.path.exists(self.obshdr), f"Header file {self.obshdr} does not exist."
         assert os.path.exists(irrfp), f"Irradiance file {irrfp} does not exist."
 
-        self.toa_arr, self.banddef, self.metadata = l1b_to_toa_arr(self.rdnhdr, self.obshdr, irrfp)
+        self.toa_arr, self.banddef, self.metadata = l1b_to_toa_arr(
+            self.rdnhdr, self.obshdr, irrfp
+        )
         self.init_class_data(rm_bands, transform, dtype, device)
+
 
 class XarrayDatasetTOA(ToaDataset):
     """
     A PyTorch dataset class for pixelwise access of top-of-atmosphere (TOA)
     reflectance data derived from toa xarray dataset.
     """
+
     def __init__(
         self,
         toa: xr.DataArray,
@@ -161,19 +167,24 @@ class SpectraDataset(Dataset):
 
     This dataset class is designed specifically for the dataset provided in:
     https://zenodo.org/records/14614218
-    
+
     Attributes:
         spectra (ndarray): The spectral data.
         labels (ndarray): The corresponding labels for the spectral data.
-        transform (callable): Transformations or normalizations 
+        transform (callable): Transformations or normalizations
                               for each spectral data point.
         device (str): The device to load the data onto (e.g., 'cpu', 'cuda:0').
     """
 
-    def __init__(self, spectra: np.ndarray, labels: np.ndarray,
-                 transform: bool = None, device: str = 'cpu'):
-        """ Initialize the SpectraDataset object.
-        
+    def __init__(
+        self,
+        spectra: np.ndarray,
+        labels: np.ndarray,
+        transform: bool = None,
+        device: str = "cpu",
+    ):
+        """Initialize the SpectraDataset object.
+
         Args:
             spectra (np.ndarray): The spectral data.
             labels (np.ndarray): The corresponding labels for the spectral data.
@@ -185,7 +196,7 @@ class SpectraDataset(Dataset):
         self.spectra = torch.tensor(spectra, dtype=torch.float32).to(device)
 
         self.labels = torch.tensor(labels).to(device)
-        self.labels[self.labels==2] = 0 # shadow considered clear
+        self.labels[self.labels == 2] = 0  # shadow considered clear
 
         self.transform = transform
 
@@ -193,12 +204,8 @@ class SpectraDataset(Dataset):
         return len(self.labels)
 
     def __getitem__(self, idx):
-
         out_spec = self.spectra[idx]
         if self.transform is not None:
             out_spec = self.transform(out_spec)
 
-        return {
-            'spectra': torch.unsqueeze(out_spec, -1),
-            'label': self.labels[idx]
-        }
+        return {"spectra": torch.unsqueeze(out_spec, -1), "label": self.labels[idx]}

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -1,4 +1,4 @@
-"""Applies the SpecTf cloud screening model to an EMIT scene.
+""" Applies the SpecTf cloud screening model to an EMIT scene.
 
 Copyright 2025 California Institute of Technology
 Apache License, Version 2.0
@@ -26,7 +26,7 @@ from spectf_cloud.deploy.gen_geotiff import make_geotiff
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
 PRECISION = torch.bfloat16
-ENV_VAR_PREFIX = "SPECTF_DEPLOY_"
+ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
 
 
 # TODO: Refactor this into the CLI
@@ -36,11 +36,10 @@ logging.basicConfig(
     format="[%(levelname)s] %(message)s",
     handlers=[
         # Uncomment to also log to a file
-        # logging.FileHandler(op.join('out.log')),
+        #logging.FileHandler(op.join('out.log')),
         logging.StreamHandler()
-    ],
+    ]
 )
-
 
 @click.argument(
     "rdnfp",
@@ -77,7 +76,7 @@ logging.basicConfig(
 )
 @click.option(
     "--weights",
-    default=DEFAULT_DIR / "weights/current.pt",
+    default=DEFAULT_DIR/"weights/current.pt",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to latest trained model weights.",
@@ -85,7 +84,7 @@ logging.basicConfig(
 )
 @click.option(
     "--irradiance",
-    default=DEFAULT_DIR / "irr.npy",
+    default=DEFAULT_DIR/"irr.npy",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to irradiance numpy file.",
@@ -93,7 +92,7 @@ logging.basicConfig(
 )
 @click.option(
     "--arch-spec",
-    default=DEFAULT_DIR / "spectf_cloud_config.yml",
+    default=DEFAULT_DIR/"spectf_cloud_config.yml",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to model architecture YAML specification. This file also needs to contain the bands to remove",
@@ -122,7 +121,7 @@ logging.basicConfig(
     OUTFP is where the output file will be written (GeoTIFF .tif)
     RDNFP is the filepath of the radiance data (ENVI .img)
     OBSFP is the filepath of the observation data (ENVI .img)
-    """,
+    """
 )
 def deploy_pt(
     rdnfp,
@@ -139,26 +138,22 @@ def deploy_pt(
     """Applies the SpecTf cloud screening model to an EMIT scene."""
 
     # Open model architecture specification from YAML file and Setup PyTorch device
-    if device != -1:
+    if device !=-1:
         device_specification = f"cuda:{device}"
     else:
         device_specification = "cpu"
 
-    spec, device_ = open_model_arch_spec(
-        arch_spec, device_specification=device_specification
-    )
+    spec, device_ = open_model_arch_spec(arch_spec, device_specification=device_specification)
 
     # Initialize dataset
-    dataset = RasterDatasetTOA(
-        rdnfp,
-        obsfp,
-        irradiance,
-        rm_bands=spec["spectra"]["drop_band_ranges"],
-        transform=None,
-        keep_bands=keep_bands,
-        dtype=PRECISION,
-        device=device_,
-    )
+    dataset = RasterDatasetTOA(rdnfp, 
+                               obsfp, 
+                               irradiance, 
+                               rm_bands=spec['spectra']['drop_band_ranges'],
+                               transform=None, 
+                               keep_bands=keep_bands, 
+                               dtype=PRECISION, 
+                               device=device_)
 
     # Initialize and run inference
     cloud_mask = run_pt_inference_model(dataset, spec, weights, device_)
@@ -170,7 +165,6 @@ def deploy_pt(
     cloud_mask_reshaped = cloud_mask.reshape(dataset.shape[0], dataset.shape[1])
 
     return cloud_mask_reshaped
-
 
 def deploy_pt_from_toa(
     toa_dataset: xr.DataArray,
@@ -210,7 +204,7 @@ def deploy_pt_from_toa(
     # Initialize dataset
     dataset = XarrayDatasetTOA(
         toa_dataset,
-        rm_bands=spec["spectra"]["drop_band_ranges"],
+        rm_bands=spec['spectra']['drop_band_ranges'],
         dtype=PRECISION,
         device=device_,
     )
@@ -262,10 +256,7 @@ def initialize_pt_model(
     model = torch.jit.optimize_for_inference(torch.jit.script(model))
     return model
 
-
-def run_pt_inference_model(
-    dataset: ToaDataset, spec: dict, weights: str, device_: torch.device
-) -> np.ndarray:
+def run_pt_inference_model(dataset: ToaDataset, spec: dict, weights: str, device_: torch.device) -> np.ndarray:
     """
     Initializes a pytorch model and runs inference on the provided dataset using the specified model architecture and
     weights.
@@ -321,7 +312,6 @@ def run_pt_inference_model(
 
     # Return cloud mask probabilities
     return cloud_mask
-
 
 if __name__ == "__main__":
     print(MAIN_CALL_ERR_MSG % "deploy-pt")

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -15,7 +15,6 @@ import rich_click as click
 import numpy as np
 
 import torch
-from isofit.utils.template_construction import Pathnames
 from torch import nn
 from torch.utils.data import DataLoader
 

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -11,16 +11,17 @@ This version of the dployment script quantizes the model, and runs it with PyTor
 import logging
 import time
 
-import yaml
 import rich_click as click
 import numpy as np
 
 import torch
+from isofit.utils.template_construction import Pathnames
 from torch import nn
 from torch.utils.data import DataLoader
 
+from spectf_cloud.deploy.infra_setup import open_model_arch_spec
 from spectf.model import SpecTfEncoder
-from spectf.dataset import RasterDatasetTOA
+from spectf.dataset import RasterDatasetTOA, XarrayDatasetTOA, ToaDataset
 from spectf_cloud.deploy.gen_geotiff import make_geotiff
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
@@ -55,7 +56,8 @@ logging.basicConfig(
 @click.argument(
     "outfp",
     type=click.Path(),
-    required=True,
+    default=None,
+    help="Output filepath for the cloud mask GeoTIFF. if no path is provided - no file will be written.",
     envvar=f"{ENV_VAR_PREFIX}OUTFP",
 )
 @click.option(
@@ -135,25 +137,15 @@ def deploy_pt(
 ):
     """Applies the SpecTf cloud screening model to an EMIT scene."""
 
-    # Open model architecture specification from YAML file
-    with open(arch_spec, 'r', encoding='utf-8') as f:
-        spec = yaml.safe_load(f)
-
-    arch = spec['architecture']
-    inference = spec['inference']
-
-    # Setup PyTorch device
-    if torch.cuda.is_available() and device != -1:
-        device_ = torch.device(f"cuda:{device}")
-        logging.info("Device is cuda:%s", device)
-    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
-        device_ = torch.device("mps") # Apple silicon
-        logging.info("Device is Apple MPS acceleration")
+    # Open model architecture specification from YAML file and Setup PyTorch device
+    if device !=-1:
+        device_specification = f"cuda:{device}"
     else:
-        device_ = torch.device("cpu")
-        logging.info("Device is CPU")
+        device_specification = "cpu"
 
-    # Initialize dataset and dataloader
+    spec, device_ = open_model_arch_spec(arch_spec, device_specification=device_specification)
+
+    # Initialize dataset
     dataset = RasterDatasetTOA(rdnfp, 
                                obsfp, 
                                irradiance, 
@@ -162,32 +154,133 @@ def deploy_pt(
                                keep_bands=keep_bands, 
                                dtype=PRECISION, 
                                device=device_)
-    dataloader = DataLoader(dataset,
-                            batch_size=inference['batch'],
-                            shuffle=False,
-                            num_workers=inference['workers'])
 
+    # Initialize and run inference
+    cloud_mask = run_pt_inference_model(dataset, spec, weights, device_)
+
+    if outfp is not None:
+        make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
+
+    return cloud_mask
+
+def deploy_pt_from_toa(
+    toa_dataset,
+    weights: str,
+    arch_spec: str,
+    proba: bool = False,
+    device: int = -1,
+    threshold: float = 0.51,
+    outfp: str | None = None,
+):
+    """
+    Applies the SpecTf cloud screening model to a top of atmosphere dataset.
+    Args:
+        toa_dataset: xr.Dataset xarray dataset containing TOA reflectance data.
+        proba: bool: Output probability map with the binary cloud mask, default False.
+        weights: str: Filepath to latest trained model weights.
+        arch_spec: str: Filepath to model architecture YAML specification.
+               This file also needs to contain the bands to remove (if desired)
+        device: int: Device specification for PyTorch (-1 for CPU, 0+ for GPU, MPS if available), default -1 (CPU).
+        threshold: float: Threshold for cloud classification, default 0.51.
+        outfp: str | None: Output filepath for the cloud mask GeoTIFF. if no path is provided - no file will be saved.
+
+    Returns:
+        cloud_mask: np.ndarray: The generated cloud mask (probability values).
+
+    """
+    # Open model architecture specification from YAML file and Setup PyTorch device
+    if device != -1:
+        device_specification = f"cuda:{device}"
+    else:
+        device_specification = "cpu"
+
+    spec, device_ = open_model_arch_spec(
+        arch_spec, device_specification=device_specification
+    )
+
+    # Initialize dataset
+    dataset = XarrayDatasetTOA(
+        toa_dataset,
+        rm_bands=spec['spectra']['drop_band_ranges'],
+        dtype=PRECISION,
+        device=device_,
+    )
+
+    # Initialize and run inference
+    cloud_mask = run_pt_inference_model(dataset, spec, weights, device_)
+
+    # Save output GeoTIFF if specified
+    if outfp is not None:
+        make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
+
+    return cloud_mask
+
+
+def initialize_pt_model(
+    arch: dict, dataset: ToaDataset, weights: str, device_: torch.device
+) -> nn.Module:
+    """
+    Initializes a PyTorch SpecTf model with the given architecture and weights.
+    Args:
+        arch: dict: Model architecture specifications.
+        dataset: ToaDataset: Dataset object containing toa data.
+        weights: str: Filepath to the model weights.
+        device_: torch.device: Device to load the model onto.
+
+    Returns:
+        model: nn.Module: The initialized PyTorch model.
+
+    """
     # Define and initialize the model
     banddef = torch.tensor(dataset.banddef, dtype=PRECISION, device=device_)
-    model = SpecTfEncoder(banddef=banddef,
-                          dim_output=2,
-                          num_heads=arch['num_heads'],
-                          dim_proj=arch['dim_proj'],
-                          dim_ff=arch['dim_ff'],
-                          agg=arch['agg'],
-                          use_residual=False,
-                          num_layers=1).to(device_, dtype=PRECISION)
+    model = SpecTfEncoder(
+        banddef=banddef,
+        dim_output=2,
+        num_heads=arch["num_heads"],
+        dim_proj=arch["dim_proj"],
+        dim_ff=arch["dim_ff"],
+        agg=arch["agg"],
+        use_residual=False,
+        num_layers=1,
+    ).to(device_, dtype=PRECISION)
     state_dict = torch.load(weights, map_location=device_)
     model.load_state_dict(state_dict)
     model.eval()
 
     # Optimize for jit
     model = torch.jit.optimize_for_inference(torch.jit.script(model))
+    return model
 
-    # Inference
+def run_pt_inference_model(dataset: ToaDataset, spec: dict, weights: str, device_: torch.device) -> np.ndarray:
+    """
+    Initializes a pytorch model and runs inference on the provided dataset using the specified model architecture and
+    weights.
+    Args:
+        dataset: ToaDataset: Dataset object containing toa data.
+        spec: dict: Model architecture specifications.
+        weights: str: Filepath to the model weights.
+        device_: torch.device: Device to run inference on.
+
+    Returns:
+        cloud_mask: np.ndarray: The generated cloud mask (probability values).
+
+    """
+    # Initialize dataloader
+    dataloader = DataLoader(
+        dataset,
+        batch_size=spec["inference"]["batch"],
+        shuffle=False,
+        num_workers=spec["inference"]["workers"],
+    )
+
+    # Initialize model
+    model = initialize_pt_model(spec["architecture"], dataset, weights, device_)
+
+    # Run Inference
+    dataset_shape = (dataset.shape[0] * dataset.shape[1],)
 
     logging.info("Starting inference.")
-    cloud_mask = np.zeros((dataset.shape[0]*dataset.shape[1],)).astype(np.float32)
+    cloud_mask = np.zeros(dataset_shape).astype(np.float32)
     total_len = len(dataloader)
     with torch.inference_mode():
         curr = 0
@@ -195,20 +288,25 @@ def deploy_pt(
         for i, batch in enumerate(dataloader):
             pred = model(batch)
             proba_ = nn.functional.softmax(pred, dim=1)
-            proba_ = proba_.to(dtype=torch.float32).cpu().detach().numpy()[:,1]
+            proba_ = proba_.to(dtype=torch.float32).cpu().detach().numpy()[:, 1]
 
-            nxt = curr+batch.size()[0]
+            nxt = curr + batch.size()[0]
             cloud_mask[curr:nxt] = proba_
 
             curr = nxt
-            if (i+1) % 100 == 0:
+            if (i + 1) % 100 == 0:
                 end = time.time()
-                logging.info("Iter %d: %.2f min remain.", i, (((end-start)/100)*(total_len-i-1))/60)
+                logging.info(
+                    "Iter %d: %.2f min remain.",
+                    i,
+                    (((end - start) / 100) * (total_len - i - 1)) / 60,
+                )
                 start = time.time()
 
     logging.info("Inference complete.")
 
-    make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
+    # Return cloud mask probabilities
+    return cloud_mask
 
 if __name__ == "__main__":
     print(MAIN_CALL_ERR_MSG % "deploy-pt")

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -13,7 +13,6 @@ import time
 
 import rich_click as click
 import numpy as np
-import xarray as xr
 
 import torch
 from torch import nn
@@ -21,7 +20,7 @@ from torch.utils.data import DataLoader
 
 from spectf_cloud.deploy.infra_setup import open_model_arch_spec
 from spectf.model import SpecTfEncoder
-from spectf.dataset import RasterDatasetTOA, XarrayDatasetTOA, ToaDataset
+from spectf.dataset import RasterDatasetTOA, ArrayDatasetTOA, ToaDataset
 from spectf_cloud.deploy.gen_geotiff import make_geotiff
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
@@ -167,7 +166,8 @@ def deploy_pt(
     return cloud_mask_reshaped
 
 def deploy_pt_from_toa(
-    toa_dataset: xr.DataArray,
+    toa_dataset: np.ndarray,
+    banddef: np.ndarray,
     weights: str,
     arch_spec: str,
     proba: bool = False,
@@ -178,7 +178,8 @@ def deploy_pt_from_toa(
     """
     Applies the SpecTf cloud screening model to a top of atmosphere dataset.
     Args:
-        toa_dataset: xr.Dataset xarray dataset containing TOA reflectance data.
+        toa_dataset: np.ndarray containing TOA reflectance data shape (rows, cols, bands) or (cols, rows, bands).
+        banddef: np.ndarray containing band wavelengths corresponding to the bands in toa_dataset.
         proba: bool: Output probability map with the binary cloud mask, default False.
         weights: str: Filepath to latest trained model weights.
         arch_spec: str: Filepath to model architecture YAML specification.
@@ -202,8 +203,9 @@ def deploy_pt_from_toa(
     )
 
     # Initialize dataset
-    dataset = XarrayDatasetTOA(
+    dataset = ArrayDatasetTOA(
         toa_dataset,
+        banddef,
         rm_bands=spec['spectra']['drop_band_ranges'],
         dtype=PRECISION,
         device=device_,

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -1,4 +1,4 @@
-""" Applies the SpecTf cloud screening model to an EMIT scene.
+"""Applies the SpecTf cloud screening model to an EMIT scene.
 
 Copyright 2025 California Institute of Technology
 Apache License, Version 2.0
@@ -26,7 +26,7 @@ from spectf_cloud.deploy.gen_geotiff import make_geotiff
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
 PRECISION = torch.bfloat16
-ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
+ENV_VAR_PREFIX = "SPECTF_DEPLOY_"
 
 
 # TODO: Refactor this into the CLI
@@ -36,10 +36,11 @@ logging.basicConfig(
     format="[%(levelname)s] %(message)s",
     handlers=[
         # Uncomment to also log to a file
-        #logging.FileHandler(op.join('out.log')),
+        # logging.FileHandler(op.join('out.log')),
         logging.StreamHandler()
-    ]
+    ],
 )
+
 
 @click.argument(
     "rdnfp",
@@ -76,7 +77,7 @@ logging.basicConfig(
 )
 @click.option(
     "--weights",
-    default=DEFAULT_DIR/"weights/current.pt",
+    default=DEFAULT_DIR / "weights/current.pt",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to latest trained model weights.",
@@ -84,7 +85,7 @@ logging.basicConfig(
 )
 @click.option(
     "--irradiance",
-    default=DEFAULT_DIR/"irr.npy",
+    default=DEFAULT_DIR / "irr.npy",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to irradiance numpy file.",
@@ -92,7 +93,7 @@ logging.basicConfig(
 )
 @click.option(
     "--arch-spec",
-    default=DEFAULT_DIR/"spectf_cloud_config.yml",
+    default=DEFAULT_DIR / "spectf_cloud_config.yml",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to model architecture YAML specification. This file also needs to contain the bands to remove",
@@ -121,7 +122,7 @@ logging.basicConfig(
     OUTFP is where the output file will be written (GeoTIFF .tif)
     RDNFP is the filepath of the radiance data (ENVI .img)
     OBSFP is the filepath of the observation data (ENVI .img)
-    """
+    """,
 )
 def deploy_pt(
     rdnfp,
@@ -138,22 +139,26 @@ def deploy_pt(
     """Applies the SpecTf cloud screening model to an EMIT scene."""
 
     # Open model architecture specification from YAML file and Setup PyTorch device
-    if device !=-1:
+    if device != -1:
         device_specification = f"cuda:{device}"
     else:
         device_specification = "cpu"
 
-    spec, device_ = open_model_arch_spec(arch_spec, device_specification=device_specification)
+    spec, device_ = open_model_arch_spec(
+        arch_spec, device_specification=device_specification
+    )
 
     # Initialize dataset
-    dataset = RasterDatasetTOA(rdnfp, 
-                               obsfp, 
-                               irradiance, 
-                               rm_bands=spec['spectra']['drop_band_ranges'],
-                               transform=None, 
-                               keep_bands=keep_bands, 
-                               dtype=PRECISION, 
-                               device=device_)
+    dataset = RasterDatasetTOA(
+        rdnfp,
+        obsfp,
+        irradiance,
+        rm_bands=spec["spectra"]["drop_band_ranges"],
+        transform=None,
+        keep_bands=keep_bands,
+        dtype=PRECISION,
+        device=device_,
+    )
 
     # Initialize and run inference
     cloud_mask = run_pt_inference_model(dataset, spec, weights, device_)
@@ -162,6 +167,7 @@ def deploy_pt(
         make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
 
     return cloud_mask
+
 
 def deploy_pt_from_toa(
     toa_dataset,
@@ -201,7 +207,7 @@ def deploy_pt_from_toa(
     # Initialize dataset
     dataset = XarrayDatasetTOA(
         toa_dataset,
-        rm_bands=spec['spectra']['drop_band_ranges'],
+        rm_bands=spec["spectra"]["drop_band_ranges"],
         dtype=PRECISION,
         device=device_,
     )
@@ -251,7 +257,10 @@ def initialize_pt_model(
     model = torch.jit.optimize_for_inference(torch.jit.script(model))
     return model
 
-def run_pt_inference_model(dataset: ToaDataset, spec: dict, weights: str, device_: torch.device) -> np.ndarray:
+
+def run_pt_inference_model(
+    dataset: ToaDataset, spec: dict, weights: str, device_: torch.device
+) -> np.ndarray:
     """
     Initializes a pytorch model and runs inference on the provided dataset using the specified model architecture and
     weights.
@@ -307,6 +316,7 @@ def run_pt_inference_model(dataset: ToaDataset, spec: dict, weights: str, device
 
     # Return cloud mask probabilities
     return cloud_mask
+
 
 if __name__ == "__main__":
     print(MAIN_CALL_ERR_MSG % "deploy-pt")

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -13,6 +13,7 @@ import time
 
 import rich_click as click
 import numpy as np
+import xarray as xr
 
 import torch
 from torch import nn
@@ -134,7 +135,7 @@ def deploy_pt(
     arch_spec,
     device,
     threshold,
-):
+) -> np.ndarray:
     """Applies the SpecTf cloud screening model to an EMIT scene."""
 
     # Open model architecture specification from YAML file and Setup PyTorch device
@@ -172,14 +173,14 @@ def deploy_pt(
 
 
 def deploy_pt_from_toa(
-    toa_dataset,
+    toa_dataset: xr.DataArray,
     weights: str,
     arch_spec: str,
     proba: bool = False,
     device: int = -1,
     threshold: float = 0.51,
     outfp: str | None = None,
-):
+) -> np.ndarray:
     """
     Applies the SpecTf cloud screening model to a top of atmosphere dataset.
     Args:

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -10,6 +10,7 @@ This version of the dployment script quantizes the model, and runs it with PyTor
 
 import logging
 import time
+from typing import Optional
 
 import rich_click as click
 import numpy as np
@@ -172,7 +173,7 @@ def deploy_pt_from_toa(
     proba: bool = False,
     device: int = -1,
     threshold: float = 0.51,
-    outfp: str | None = None,
+    outfp: Optional[str] = None,
 ) -> np.ndarray:
     """
     Applies the SpecTf cloud screening model to a top of atmosphere dataset.

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -166,7 +166,10 @@ def deploy_pt(
     if outfp is not None:
         make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
 
-    return cloud_mask
+    # reshape back to original image shape (rows, cols) or (cols, rows)
+    cloud_mask_reshaped = cloud_mask.reshape(dataset.shape[0], dataset.shape[1])
+
+    return cloud_mask_reshaped
 
 
 def deploy_pt_from_toa(
@@ -219,7 +222,9 @@ def deploy_pt_from_toa(
     if outfp is not None:
         make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
 
-    return cloud_mask
+    # reshape back to original image shape (rows, cols) or (cols, rows)
+    cloud_mask_reshaped = cloud_mask.reshape(dataset.shape[0], dataset.shape[1])
+    return cloud_mask_reshaped
 
 
 def initialize_pt_model(
@@ -303,7 +308,7 @@ def run_pt_inference_model(
             cloud_mask[curr:nxt] = proba_
 
             curr = nxt
-            if (i + 1) % 100 == 0:
+            if i % 100 == 0:
                 end = time.time()
                 logging.info(
                     "Iter %d: %.2f min remain.",

--- a/spectf_cloud/deploy/deploy_pt.py
+++ b/spectf_cloud/deploy/deploy_pt.py
@@ -56,7 +56,6 @@ logging.basicConfig(
     "outfp",
     type=click.Path(),
     default=None,
-    help="Output filepath for the cloud mask GeoTIFF. if no path is provided - no file will be written.",
     envvar=f"{ENV_VAR_PREFIX}OUTFP",
 )
 @click.option(

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -14,7 +14,6 @@ import time
 import rich_click as click
 import numpy as np
 from osgeo import gdal
-import xarray as xr
 
 from spectf_cloud.deploy.infra_setup import open_model_arch_spec
 
@@ -24,7 +23,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from spectf.model import BandConcat
-from spectf.dataset import RasterDatasetTOA, XarrayDatasetTOA
+from spectf.dataset import RasterDatasetTOA, ArrayDatasetTOA
 from spectf_cloud.deploy.gen_geotiff import make_geotiff
 from spectf_cloud.deploy.tensor_rt_model import load_model_network_engine
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
@@ -158,7 +157,8 @@ def deploy_trt(
     return cloud_mask
 
 def deploy_trt_from_toa(
-    toa_dataset: xr.DataArray,
+    toa_dataset: np.ndarray,
+    banddef: np.ndarray,
     engine_fp: str,
     arch_spec: str,
     proba: bool = False,
@@ -168,7 +168,8 @@ def deploy_trt_from_toa(
     """
     Applies the SpecTf cloud screening model to a scene
     Args:
-        toa_dataset: xr.Dataset xarray dataset containing TOA reflectance data.
+        toa_dataset: np.ndarray containing TOA reflectance data shape (rows, cols, bands) or (cols, rows, bands).
+        banddef: np.ndarray containing band wavelengths corresponding to the bands in toa_dataset.
         engine_fp: filepath to the TensorRT engine file
         arch_spec: str: Filepath to model architecture YAML specification.
                This file also needs to contain the bands to remove (if desired)
@@ -188,8 +189,9 @@ def deploy_trt_from_toa(
     inference = spec["inference"]
 
     # Initialize dataset
-    dataset = XarrayDatasetTOA(
+    dataset = ArrayDatasetTOA(
         toa_dataset,
+        banddef,
         rm_bands=spec["spectra"]["drop_band_ranges"],
         dtype=PRECISION,
         device=device_,

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -14,6 +14,7 @@ import time
 import rich_click as click
 import numpy as np
 from osgeo import gdal
+import xarray as xr
 
 from spectf_cloud.deploy.infra_setup import open_model_arch_spec
 
@@ -23,11 +24,11 @@ import torch
 from torch.utils.data import DataLoader
 
 from spectf.model import BandConcat
-from spectf.dataset import RasterDatasetTOA
+from spectf.dataset import RasterDatasetTOA, XarrayDatasetTOA
 from spectf_cloud.deploy.gen_geotiff import make_geotiff
+from spectf_cloud.deploy.tensor_rt_model import load_model_network_engine
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
-from spectf_cloud.deploy.tensor_rt_model import load_model_network_engine
 import tensorrt as trt
 import pycuda.driver as cuda
 
@@ -132,7 +133,7 @@ def deploy_trt(
     irradiance,
     arch_spec,
     threshold,
-):
+) -> np.ndarray:
     """Applies the SpecTf cloud screening model to an EMIT scene."""
     if not torch.cuda.is_available():
         raise RuntimeError(
@@ -161,6 +162,51 @@ def deploy_trt(
 
     return cloud_mask
 
+
+def deploy_trt_from_toa(
+    toa_dataset: xr.DataArray,
+    engine_fp: str,
+    arch_spec: str,
+    proba: bool = False,
+    threshold: float = 0.51,
+    outfp: str | None = None,
+) -> np.ndarray:
+    """
+    Applies the SpecTf cloud screening model to a scene
+    Args:
+        toa_dataset: xr.Dataset xarray dataset containing TOA reflectance data.
+        engine_fp: filepath to the TensorRT engine file
+        arch_spec: str: Filepath to model architecture YAML specification.
+               This file also needs to contain the bands to remove (if desired)
+        proba: bool: Output probability map with the binary cloud mask, default False.
+        threshold: float: Threshold for cloud classification, default 0.51.
+        outfp:  str | None: Output filepath for the cloud mask GeoTIFF. if no path is provided - no file will be saved.
+
+    Returns:
+        cloud_mask: np.ndarray: The generated cloud mask (probability values).
+    """
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "Cannot run the TensorRT runt time engine without a CUDA supported GPU."
+        )
+
+    spec, device_ = open_model_arch_spec(arch_spec, device_specification="cuda")
+    inference = spec["inference"]
+
+    # Initialize dataset
+    dataset = XarrayDatasetTOA(
+        toa_dataset,
+        rm_bands=spec["spectra"]["drop_band_ranges"],
+        dtype=PRECISION,
+        device=device_,
+    )
+
+    cloud_mask = run_trt_inference_model(dataset, engine_fp, inference, device_)
+
+    if outfp is not None:
+        make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
+
+    return cloud_mask
 
 def pad_batch(b: torch.Tensor, target_bsz: int):
     # Pad w/ zeros

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -11,10 +11,12 @@ This version of the dployment script quantizes the model, and runs it with Nvidi
 import logging
 import time
 
-import yaml
 import rich_click as click
 import numpy as np
 from osgeo import gdal
+
+from spectf_cloud.deploy.infra_setup import open_model_arch_spec
+
 gdal.UseExceptions()
 
 import torch
@@ -28,7 +30,6 @@ from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 from spectf_cloud.deploy.tensor_rt_model import load_model_network_engine
 import tensorrt as trt
 import pycuda.driver as cuda
-import pycuda.autoinit
 
 PRECISION = torch.bfloat16
 ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
@@ -61,7 +62,8 @@ logging.basicConfig(
 @click.argument(
     "outfp",
     type=click.Path(),
-    required=True,
+    default=None,
+    help="Output filepath for the cloud mask GeoTIFF. if no path is provided - no file will be written.",
     envvar=f"{ENV_VAR_PREFIX}OUTFP",
 )
 @click.option(
@@ -134,12 +136,8 @@ def deploy_trt(
     if not torch.cuda.is_available():
         raise RuntimeError("Cannot run the TensorRT runt time engine without a CUDA supported GPU.")
 
-    # Open model architecture specification from YAML file
-    with open(arch_spec, 'r', encoding='utf-8') as f:
-        spec = yaml.safe_load(f)
+    spec, device_ = open_model_arch_spec(arch_spec, device_specification="cuda")
     inference = spec['inference']
-    
-    device_ = torch.device("cuda")
 
     # Initialize dataset and dataloader
     dataset = RasterDatasetTOA(rdnfp, 
@@ -150,92 +148,13 @@ def deploy_trt(
                                keep_bands=keep_bands, 
                                dtype=PRECISION, 
                                device=device_)
-    banddef = torch.tensor(dataset.banddef, dtype=PRECISION).to(device_)
-    bc = BandConcat(banddef)
-    dataset.toa_arr = bc(dataset.toa_arr)
-    dataloader = DataLoader(dataset,
-                            batch_size=inference['batch'],
-                            shuffle=False,
-                            num_workers=inference['workers'])
 
-    # Define and initialize the model
-    engine = load_model_network_engine(engine)
-    context = engine.create_execution_context()
+    cloud_mask = run_trt_inference_model(dataset, engine, inference, device_)
 
-    ## Allocate buffers
-    input_name = None
-    expected_bsz = -1
-    for i in range(engine.num_io_tensors):
-        tensor_name = engine.get_tensor_name(i)
-        size = trt.volume(engine.get_tensor_shape(tensor_name))
-        
-        if engine.get_tensor_mode(tensor_name) == trt.TensorIOMode.INPUT:
-            input_name = tensor_name
-            expected_bsz = engine.get_tensor_shape(tensor_name)[0]
-        else:
-            host_ouput_buffer = cuda.pagelocked_empty(size, dtype=np.float16)
-            device_output_buffer = cuda.mem_alloc(host_ouput_buffer.nbytes)
+    if outfp is not None:
+        make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
 
-            context.set_tensor_address(tensor_name, int(device_output_buffer))
-    stream = cuda.Stream()
-
-    # Inference
-    
-    logging.info("Starting inference.")
-    cloud_mask = np.zeros((dataset.shape[0]*dataset.shape[1],)).astype(np.float32)
-    total_len = len(dataloader)
-    with torch.inference_mode():
-        curr = 0
-        start = time.time()
-        for i, batch in enumerate(dataloader):
-            # If the batch size is smaller than needed (happens for last batch), we neeed to pad it
-            original_pad_shape = -1
-            if inference['batch'] != batch.size(0):
-                original_pad_shape = batch.size(0)
-                batch = pad_batch(batch, inference['batch'])
-            if expected_bsz != -1:
-                assert batch.size(0) == expected_bsz, f"Got unsupported batch size. Got: {batch.shape(0)} | Need: {expected_bsz}"
-
-            # Create an input buffer
-            batch = batch.contiguous() # should be of shape: (bsz, n dims, 2 - for the spectra and index)
-            context.set_tensor_address(input_name, int(batch.data_ptr()))
-
-            # Execute inference
-            context.execute_async_v3(stream.handle)
-
-            out_gpu = torch.empty((batch.shape[0], 2), dtype=PRECISION, device=device_)
-            # Device->Device copy from device_output buffer into tensor
-            cuda.memcpy_dtod_async(
-                dest=out_gpu.data_ptr(),
-                src=device_output_buffer,
-                size=out_gpu.numel() * out_gpu.element_size(),
-                stream=stream
-            )
-            stream.synchronize()
-
-            # Perform softmax on the GPU - putting this here versus fusing with the trt network had no benefits
-            proba_gpu = torch.nn.functional.softmax(out_gpu.float(), dim=1)
-
-            # Bring the result back to CPU
-            proba_ = proba_gpu.to(dtype=torch.float32).cpu().detach().numpy()[:,1]
-
-            if original_pad_shape != -1:
-                nxt = curr+original_pad_shape
-                proba_ = proba_[:original_pad_shape]
-            else:
-                nxt = curr+batch.size(0)
-            
-            cloud_mask[curr:nxt] = proba_
-
-            curr = nxt
-            if (i+1) % 100 == 0:
-                end = time.time()
-                logging.info("Iter %d: %.2f min remain.", i, (((end-start)/100)*(total_len-i-1))/60)
-                start = time.time()
-
-    logging.info("Inference complete.")
-
-    make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
+    return cloud_mask
 
 def pad_batch(b: torch.Tensor, target_bsz:int):    
     # Pad w/ zeros
@@ -248,6 +167,102 @@ def pad_batch(b: torch.Tensor, target_bsz:int):
 
     padded_batch[:b.size(0)] = b
     return padded_batch
+
+def run_trt_inference_model(dataset, engine, inference, device_):
+    banddef = torch.tensor(dataset.banddef, dtype=PRECISION).to(device_)
+    bc = BandConcat(banddef)
+    dataset.toa_arr = bc(dataset.toa_arr)
+    dataloader = DataLoader(dataset,
+                            batch_size=inference['batch'],
+                            shuffle=False,
+                            num_workers=inference['workers'])
+
+    # Inference
+    dataset_shape = (dataset.shape[0] * dataset.shape[1],)
+
+    # Define and initialize the model
+    engine = load_model_network_engine(engine)
+    context = engine.create_execution_context()
+
+    ## Allocate buffers
+    input_name = None
+    expected_bsz = -1
+    for i in range(engine.num_io_tensors):
+        tensor_name = engine.get_tensor_name(i)
+        size = trt.volume(engine.get_tensor_shape(tensor_name))
+
+        if engine.get_tensor_mode(tensor_name) == trt.TensorIOMode.INPUT:
+            input_name = tensor_name
+            expected_bsz = engine.get_tensor_shape(tensor_name)[0]
+        else:
+            host_ouput_buffer = cuda.pagelocked_empty(size, dtype=np.float16)
+            device_output_buffer = cuda.mem_alloc(host_ouput_buffer.nbytes)
+
+            context.set_tensor_address(tensor_name, int(device_output_buffer))
+    stream = cuda.Stream()
+
+    logging.info("Starting inference.")
+    cloud_mask = np.zeros(dataset_shape).astype(np.float32)
+    total_len = len(dataloader)
+    with torch.inference_mode():
+        curr = 0
+        start = time.time()
+        for i, batch in enumerate(dataloader):
+            # If the batch size is smaller than needed (happens for last batch), we neeed to pad it
+            original_pad_shape = -1
+            if inference["batch"] != batch.size(0):
+                original_pad_shape = batch.size(0)
+                batch = pad_batch(batch, inference["batch"])
+            if expected_bsz != -1:
+                assert batch.size(0) == expected_bsz, (
+                    f"Got unsupported batch size. Got: {batch.shape(0)} | Need: {expected_bsz}"
+                )
+
+            # Create an input buffer
+            batch = (
+                batch.contiguous()
+            )  # should be of shape: (bsz, n dims, 2 - for the spectra and index)
+            context.set_tensor_address(input_name, int(batch.data_ptr()))
+
+            # Execute inference
+            context.execute_async_v3(stream.handle)
+
+            out_gpu = torch.empty((batch.shape[0], 2), dtype=PRECISION, device=device_)
+            # Device->Device copy from device_output buffer into tensor
+            cuda.memcpy_dtod_async(
+                dest=out_gpu.data_ptr(),
+                src=device_output_buffer,
+                size=out_gpu.numel() * out_gpu.element_size(),
+                stream=stream,
+            )
+            stream.synchronize()
+
+            # Perform softmax on the GPU - putting this here versus fusing with the trt network had no benefits
+            proba_gpu = torch.nn.functional.softmax(out_gpu.float(), dim=1)
+
+            # Bring the result back to CPU
+            proba_ = proba_gpu.to(dtype=torch.float32).cpu().detach().numpy()[:, 1]
+
+            if original_pad_shape != -1:
+                nxt = curr + original_pad_shape
+                proba_ = proba_[:original_pad_shape]
+            else:
+                nxt = curr + batch.size(0)
+
+            cloud_mask[curr:nxt] = proba_
+
+            curr = nxt
+            if (i + 1) % 100 == 0:
+                end = time.time()
+                logging.info(
+                    "Iter %d: %.2f min remain.",
+                    i,
+                    (((end - start) / 100) * (total_len - i - 1)) / 60,
+                )
+                start = time.time()
+
+    logging.info("Inference complete.")
+    return cloud_mask
 
 
 if __name__ == "__main__":

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -15,8 +15,6 @@ import rich_click as click
 import numpy as np
 from osgeo import gdal
 
-from spectf_cloud.deploy.infra_setup import open_model_arch_spec
-
 gdal.UseExceptions()
 
 import torch
@@ -27,6 +25,7 @@ from spectf.dataset import RasterDatasetTOA, ArrayDatasetTOA
 from spectf_cloud.deploy.gen_geotiff import make_geotiff
 from spectf_cloud.deploy.tensor_rt_model import load_model_network_engine
 from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
+from spectf_cloud.deploy.infra_setup import open_model_arch_spec
 
 import tensorrt as trt
 import pycuda.driver as cuda

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -30,6 +30,7 @@ from spectf_cloud.cli import spectf_cloud, MAIN_CALL_ERR_MSG, DEFAULT_DIR
 
 import tensorrt as trt
 import pycuda.driver as cuda
+import pycuda.autoinit
 
 PRECISION = torch.bfloat16
 ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
@@ -63,7 +64,6 @@ logging.basicConfig(
     "outfp",
     type=click.Path(),
     default=None,
-    help="Output filepath for the cloud mask GeoTIFF. if no path is provided - no file will be written.",
     envvar=f"{ENV_VAR_PREFIX}OUTFP",
 )
 @click.option(

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -1,4 +1,4 @@
-"""Applies the SpecTf cloud screening model to an EMIT scene.
+""" Applies the SpecTf cloud screening model to an EMIT scene.
 
 Copyright 2025 California Institute of Technology
 Apache License, Version 2.0
@@ -33,7 +33,7 @@ import tensorrt as trt
 import pycuda.driver as cuda
 
 PRECISION = torch.bfloat16
-ENV_VAR_PREFIX = "SPECTF_DEPLOY_"
+ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
 
 
 # TODO: Refactor this into the CLI
@@ -43,11 +43,10 @@ logging.basicConfig(
     format="[%(levelname)s] %(message)s",
     handlers=[
         # Uncomment to also log to a file
-        # logging.FileHandler(op.join('out.log')),
+        #logging.FileHandler(op.join('out.log')),
         logging.StreamHandler()
-    ],
+    ]
 )
-
 
 @click.argument(
     "rdnfp",
@@ -84,7 +83,7 @@ logging.basicConfig(
 )
 @click.option(
     "--engine",
-    default=DEFAULT_DIR / "weights/current.engine",
+    default=DEFAULT_DIR/"weights/current.engine",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to TensoRT model engine.",
@@ -92,7 +91,7 @@ logging.basicConfig(
 )
 @click.option(
     "--irradiance",
-    default=DEFAULT_DIR / "irr.npy",
+    default=DEFAULT_DIR/"irr.npy",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to irradiance numpy file.",
@@ -100,7 +99,7 @@ logging.basicConfig(
 )
 @click.option(
     "--arch-spec",
-    default=DEFAULT_DIR / "spectf_cloud_config.yml",
+    default=DEFAULT_DIR/"spectf_cloud_config.yml",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to model architecture YAML specification. This file also needs to contain the bands to remove",
@@ -121,7 +120,7 @@ logging.basicConfig(
     OUTFP is where the output file will be written (GeoTIFF .tif)
     RDNFP is the filepath of the radiance data (ENVI .img)
     OBSFP is the filepath of the observation data (ENVI .img)
-    """,
+    """
 )
 def deploy_trt(
     rdnfp,
@@ -136,24 +135,20 @@ def deploy_trt(
 ) -> np.ndarray:
     """Applies the SpecTf cloud screening model to an EMIT scene."""
     if not torch.cuda.is_available():
-        raise RuntimeError(
-            "Cannot run the TensorRT runt time engine without a CUDA supported GPU."
-        )
+        raise RuntimeError("Cannot run the TensorRT runt time engine without a CUDA supported GPU.")
 
     spec, device_ = open_model_arch_spec(arch_spec, device_specification="cuda")
-    inference = spec["inference"]
+    inference = spec['inference']
 
     # Initialize dataset and dataloader
-    dataset = RasterDatasetTOA(
-        rdnfp,
-        obsfp,
-        irradiance,
-        rm_bands=spec["spectra"]["drop_band_ranges"],
-        transform=None,
-        keep_bands=keep_bands,
-        dtype=PRECISION,
-        device=device_,
-    )
+    dataset = RasterDatasetTOA(rdnfp,
+                               obsfp,
+                               irradiance,
+                               rm_bands=spec['spectra']['drop_band_ranges'],
+                               transform=None,
+                               keep_bands=keep_bands,
+                               dtype=PRECISION,
+                               device=device_)
 
     cloud_mask = run_trt_inference_model(dataset, engine, inference, device_)
 
@@ -161,7 +156,6 @@ def deploy_trt(
         make_geotiff(cloud_mask, dataset.shape, outfp, proba, threshold)
 
     return cloud_mask
-
 
 def deploy_trt_from_toa(
     toa_dataset: xr.DataArray,
@@ -208,25 +202,26 @@ def deploy_trt_from_toa(
 
     return cloud_mask
 
-def pad_batch(b: torch.Tensor, target_bsz: int):
+def pad_batch(b: torch.Tensor, target_bsz:int):
     # Pad w/ zeros
     padded_shape = (target_bsz,) + b.shape[1:]
-    padded_batch = torch.zeros(padded_shape, dtype=b.dtype, device=b.device)
+    padded_batch = torch.zeros(
+        padded_shape,
+        dtype=b.dtype,
+        device=b.device
+    )
 
-    padded_batch[: b.size(0)] = b
+    padded_batch[:b.size(0)] = b
     return padded_batch
-
 
 def run_trt_inference_model(dataset, engine, inference, device_):
     banddef = torch.tensor(dataset.banddef, dtype=PRECISION).to(device_)
     bc = BandConcat(banddef)
     dataset.toa_arr = bc(dataset.toa_arr)
-    dataloader = DataLoader(
-        dataset,
-        batch_size=inference["batch"],
-        shuffle=False,
-        num_workers=inference["workers"],
-    )
+    dataloader = DataLoader(dataset,
+                            batch_size=inference['batch'],
+                            shuffle=False,
+                            num_workers=inference['workers'])
 
     # Inference
     dataset_shape = (dataset.shape[0] * dataset.shape[1],)

--- a/spectf_cloud/deploy/deploy_trt.py
+++ b/spectf_cloud/deploy/deploy_trt.py
@@ -1,4 +1,4 @@
-""" Applies the SpecTf cloud screening model to an EMIT scene.
+"""Applies the SpecTf cloud screening model to an EMIT scene.
 
 Copyright 2025 California Institute of Technology
 Apache License, Version 2.0
@@ -32,7 +32,7 @@ import tensorrt as trt
 import pycuda.driver as cuda
 
 PRECISION = torch.bfloat16
-ENV_VAR_PREFIX = 'SPECTF_DEPLOY_'
+ENV_VAR_PREFIX = "SPECTF_DEPLOY_"
 
 
 # TODO: Refactor this into the CLI
@@ -42,10 +42,11 @@ logging.basicConfig(
     format="[%(levelname)s] %(message)s",
     handlers=[
         # Uncomment to also log to a file
-        #logging.FileHandler(op.join('out.log')),
+        # logging.FileHandler(op.join('out.log')),
         logging.StreamHandler()
-    ]
+    ],
 )
+
 
 @click.argument(
     "rdnfp",
@@ -82,7 +83,7 @@ logging.basicConfig(
 )
 @click.option(
     "--engine",
-    default=DEFAULT_DIR/"weights/current.engine",
+    default=DEFAULT_DIR / "weights/current.engine",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to TensoRT model engine.",
@@ -90,7 +91,7 @@ logging.basicConfig(
 )
 @click.option(
     "--irradiance",
-    default=DEFAULT_DIR/"irr.npy",
+    default=DEFAULT_DIR / "irr.npy",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to irradiance numpy file.",
@@ -98,7 +99,7 @@ logging.basicConfig(
 )
 @click.option(
     "--arch-spec",
-    default=DEFAULT_DIR/"spectf_cloud_config.yml",
+    default=DEFAULT_DIR / "spectf_cloud_config.yml",
     type=click.Path(exists=True, dir_okay=False),
     show_default=True,
     help="Filepath to model architecture YAML specification. This file also needs to contain the bands to remove",
@@ -119,7 +120,7 @@ logging.basicConfig(
     OUTFP is where the output file will be written (GeoTIFF .tif)
     RDNFP is the filepath of the radiance data (ENVI .img)
     OBSFP is the filepath of the observation data (ENVI .img)
-    """
+    """,
 )
 def deploy_trt(
     rdnfp,
@@ -134,20 +135,24 @@ def deploy_trt(
 ):
     """Applies the SpecTf cloud screening model to an EMIT scene."""
     if not torch.cuda.is_available():
-        raise RuntimeError("Cannot run the TensorRT runt time engine without a CUDA supported GPU.")
+        raise RuntimeError(
+            "Cannot run the TensorRT runt time engine without a CUDA supported GPU."
+        )
 
     spec, device_ = open_model_arch_spec(arch_spec, device_specification="cuda")
-    inference = spec['inference']
+    inference = spec["inference"]
 
     # Initialize dataset and dataloader
-    dataset = RasterDatasetTOA(rdnfp, 
-                               obsfp, 
-                               irradiance, 
-                               rm_bands=spec['spectra']['drop_band_ranges'],
-                               transform=None, 
-                               keep_bands=keep_bands, 
-                               dtype=PRECISION, 
-                               device=device_)
+    dataset = RasterDatasetTOA(
+        rdnfp,
+        obsfp,
+        irradiance,
+        rm_bands=spec["spectra"]["drop_band_ranges"],
+        transform=None,
+        keep_bands=keep_bands,
+        dtype=PRECISION,
+        device=device_,
+    )
 
     cloud_mask = run_trt_inference_model(dataset, engine, inference, device_)
 
@@ -156,26 +161,26 @@ def deploy_trt(
 
     return cloud_mask
 
-def pad_batch(b: torch.Tensor, target_bsz:int):    
+
+def pad_batch(b: torch.Tensor, target_bsz: int):
     # Pad w/ zeros
     padded_shape = (target_bsz,) + b.shape[1:]
-    padded_batch = torch.zeros(
-        padded_shape,
-        dtype=b.dtype,
-        device=b.device
-    )
+    padded_batch = torch.zeros(padded_shape, dtype=b.dtype, device=b.device)
 
-    padded_batch[:b.size(0)] = b
+    padded_batch[: b.size(0)] = b
     return padded_batch
+
 
 def run_trt_inference_model(dataset, engine, inference, device_):
     banddef = torch.tensor(dataset.banddef, dtype=PRECISION).to(device_)
     bc = BandConcat(banddef)
     dataset.toa_arr = bc(dataset.toa_arr)
-    dataloader = DataLoader(dataset,
-                            batch_size=inference['batch'],
-                            shuffle=False,
-                            num_workers=inference['workers'])
+    dataloader = DataLoader(
+        dataset,
+        batch_size=inference["batch"],
+        shuffle=False,
+        num_workers=inference["workers"],
+    )
 
     # Inference
     dataset_shape = (dataset.shape[0] * dataset.shape[1],)

--- a/spectf_cloud/deploy/infra_setup.py
+++ b/spectf_cloud/deploy/infra_setup.py
@@ -8,10 +8,11 @@ logging.basicConfig(
     format="[%(levelname)s] %(message)s",
     handlers=[
         # Uncomment to also log to a file
-        #logging.FileHandler(op.join('out.log')),
+        # logging.FileHandler(op.join('out.log')),
         logging.StreamHandler()
-    ]
+    ],
 )
+
 
 def open_model_arch_spec(arch_spec: str, device_specification: str):
     """
@@ -26,7 +27,7 @@ def open_model_arch_spec(arch_spec: str, device_specification: str):
         device_ (torch.device): PyTorch device object for computation.
     """
     # Open model architecture specification from YAML file
-    with open(arch_spec, 'r', encoding='utf-8') as f:
+    with open(arch_spec, "r", encoding="utf-8") as f:
         spec = yaml.safe_load(f)
 
     # Setup PyTorch device
@@ -36,7 +37,7 @@ def open_model_arch_spec(arch_spec: str, device_specification: str):
     elif device_specification.startswith("cpu"):
         # first try MPS if available
         if torch.backends.mps.is_available() and torch.backends.mps.is_built():
-            device_ = torch.device("mps") # Apple silicon
+            device_ = torch.device("mps")  # Apple silicon
             logging.info("Device is Apple MPS acceleration")
         # otherwise use CPU
         else:

--- a/spectf_cloud/deploy/infra_setup.py
+++ b/spectf_cloud/deploy/infra_setup.py
@@ -1,0 +1,48 @@
+import logging
+import yaml
+import torch
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)s] %(message)s",
+    handlers=[
+        # Uncomment to also log to a file
+        #logging.FileHandler(op.join('out.log')),
+        logging.StreamHandler()
+    ]
+)
+
+def open_model_arch_spec(arch_spec: str, device_specification: str):
+    """
+    Opens the model architecture specification from a YAML file.
+
+    Args:
+        arch_spec (str): Filepath to the model architecture YAML specification.
+        device_specification: str: Device specification string (e.g., "cuda:0", "cpu").
+
+    Returns:
+        spec (dict): Dictionary containing the model architecture and inference specifications.
+        device_ (torch.device): PyTorch device object for computation.
+    """
+    # Open model architecture specification from YAML file
+    with open(arch_spec, 'r', encoding='utf-8') as f:
+        spec = yaml.safe_load(f)
+
+    # Setup PyTorch device
+    if device_specification.startswith("cuda") and torch.cuda.is_available():
+        device_ = torch.device(device_specification)
+        logging.info(f"Device is {device_specification}")
+    elif device_specification.startswith("cpu"):
+        # first try MPS if available
+        if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+            device_ = torch.device("mps") # Apple silicon
+            logging.info("Device is Apple MPS acceleration")
+        # otherwise use CPU
+        else:
+            device_ = torch.device("cpu")
+            logging.info("Device is CPU")
+    else:
+        raise ValueError(f"Unsupported device specification: {device_specification}")
+
+    return spec, device_

--- a/spectf_cloud/deploy/infra_setup.py
+++ b/spectf_cloud/deploy/infra_setup.py
@@ -2,19 +2,8 @@ import logging
 import yaml
 import torch
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-    handlers=[
-        # Uncomment to also log to a file
-        # logging.FileHandler(op.join('out.log')),
-        logging.StreamHandler()
-    ],
-)
 
-
-def open_model_arch_spec(arch_spec: str, device_specification: str):
+def open_model_arch_spec(arch_spec: str, device_specification: str) -> tuple[dict, torch.device]:
     """
     Opens the model architecture specification from a YAML file.
 
@@ -34,7 +23,7 @@ def open_model_arch_spec(arch_spec: str, device_specification: str):
     if device_specification.startswith("cuda") and torch.cuda.is_available():
         device_ = torch.device(device_specification)
         logging.info(f"Device is {device_specification}")
-    elif device_specification.startswith("cpu"):
+    elif device_specification.startswith("cpu") or device_specification.startswith("mps"):
         # first try MPS if available
         if torch.backends.mps.is_available() and torch.backends.mps.is_built():
             device_ = torch.device("mps")  # Apple silicon

--- a/spectf_cloud/deploy/infra_setup.py
+++ b/spectf_cloud/deploy/infra_setup.py
@@ -16,7 +16,7 @@ def open_model_arch_spec(arch_spec: str, device_specification: str) -> tuple[dic
         device_ (torch.device): PyTorch device object for computation.
     """
     # Open model architecture specification from YAML file
-    with open(arch_spec, "r", encoding="utf-8") as f:
+    with open(arch_spec, 'r', encoding='utf-8') as f:
         spec = yaml.safe_load(f)
 
     # Setup PyTorch device
@@ -26,7 +26,7 @@ def open_model_arch_spec(arch_spec: str, device_specification: str) -> tuple[dic
     elif device_specification.startswith("cpu") or device_specification.startswith("mps"):
         # first try MPS if available
         if torch.backends.mps.is_available() and torch.backends.mps.is_built():
-            device_ = torch.device("mps")  # Apple silicon
+            device_ = torch.device("mps") # Apple silicon
             logging.info("Device is Apple MPS acceleration")
         # otherwise use CPU
         else:


### PR DESCRIPTION
# Summary of changes:
* Pulls out and adds functions for smaller general workflows that can be reused
* adds a new way to start from a TOA xarray dataset and run inference as opposed to providing radiance asset paths.

# Specific changes
spectf/dataset.py
* New ToaDataset class that initializes the settings/parameters needed for downstream workflows
* RasterDatasetTOA inherits from ToaDataset
* New XarrayDatasetTOA class that inherits from ToaDataset that takes an input of an xarray top of atmosphere

spectf_cloud/deploy/infra_setup.py
* adds a new `open_model_arch_spec` that parses and loads the model spec

spectf_cloud/deploy/deploy_pt.py
* make the `outfp` input optional - if nothing is provided - no file will be saved
* return the inference mask from the `deploy_pt` workflow
* move core model setup to `initialize_pt_model` function
* move core model run to `run_pt_inference_model` function
* Uses the new `initialize_pt_model` and `run_pt_inference_model` in the `deplot_pt` function
* Adds a new `deploy_pt_from_toa` function that takes an xarray dataset as an input instead of filepaths
* uses the more generic `open_model_arch_spec`

spectf_cloud/deploy/deploy_trt.py
* make the `outfp` input optional - if nothing is provided - no file will be saved
* return the inference mask from the `deploy_pt` workflow
* move core model setup + run to `run_trt_inference_model` function
* Uses the new `run_trt_inference_model` in the `deploy_trt` function

## other notes
I think there are some further optimizations we can do such as converting the pt/trt models into classes - they do similar things and this can be further improved using class structure. I'll make an issue for some of the ideas I had as I was looking through.

Let me know your thoughts!